### PR TITLE
Add responsive layout variants for mobile and desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,39 @@
     .toast{position:fixed; right:16px; bottom:16px; background:#111827; color:#fff; padding:10px 12px; border-radius:12px; opacity:.95; animation:slideup .25s ease}
     .pill{display:inline-block; padding:3px 8px; border-radius:999px; background:#eef4ff; color:#4b61d1; font-weight:700}
 
+    /* responsive layouts */
+    @media (max-width: 1024px){
+      .app{padding:16px; gap:14px}
+      header{align-items:flex-start; gap:10px}
+      header .opts{flex-wrap:wrap; justify-content:flex-end; width:100%}
+      .board{grid-template-columns: minmax(0,1fr); grid-template-rows:auto auto; gap:14px}
+      .table{min-height:420px}
+      .right{order:-1}
+      .zones{grid-template-columns: repeat(2, minmax(0,1fr))}
+    }
+
+    @media (max-width: 720px){
+      body{background:
+        radial-gradient(900px 480px at 10% -10%, #eef2ff 0%, transparent 60%),
+        radial-gradient(600px 320px at 110% 0%, #ffe9f4 0%, transparent 60%), var(--bg);}
+      .app{padding:12px; gap:10px}
+      header{flex-direction:column; align-items:stretch; gap:6px}
+      header h1{font-size:16px}
+      header .opts{justify-content:space-between; gap:6px}
+      header .opts label{flex:1 1 160px}
+      .board{gap:12px}
+      .table{padding:12px; border-radius:20px; min-height:360px}
+      .panel{padding:10px}
+      .zones{grid-template-columns: minmax(0,1fr)}
+      .zone{min-height:120px}
+      .hud{gap:6px}
+      .zone .hud{width:100%; justify-content:space-between}
+      .zone .hud button{flex:1 1 calc(50% - 6px)}
+      .card{width:64px; height:90px}
+      .meld .cards{gap:-40px}
+      .toast{right:12px; bottom:12px}
+    }
+
     /* animations */
     @keyframes slideup{from{transform:translateY(12px); opacity:0} to{transform:translateY(0); opacity:1}}
     @keyframes pop{from{transform:scale(.96)} to{transform:scale(1)}}


### PR DESCRIPTION
## Summary
- add responsive breakpoints to reorganize the board for tablet and mobile widths
- adjust spacing, typography, and card sizing for smaller screens to improve usability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddb57a097c832e97ad6a02cbbe8874