### PR TITLE
Fix lingering bot autoplay timers when restarting rounds

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -14,7 +14,8 @@
     players: [],
     log: [],
     currentTurn: 0,
-    pendingBot: false
+    pendingBot: false,
+    botTimeoutId: null
   };
 
   var localPlayerName = 'YOU';
@@ -130,10 +131,18 @@
     maybeBotTurn();
   }
 
+  function clearBotTimer() {
+    if (state.botTimeoutId !== null) {
+      window.clearTimeout(state.botTimeoutId);
+      state.botTimeoutId = null;
+    }
+  }
+
   function maybeBotTurn() {
     var player = currentPlayer();
     if (!player || !player.isBot) {
       state.pendingBot = false;
+      clearBotTimer();
       drawUI();
       return;
     }
@@ -142,14 +151,17 @@
     }
     state.pendingBot = true;
     drawUI();
-    window.setTimeout(function () {
+    clearBotTimer();
+    state.botTimeoutId = window.setTimeout(function () {
       pushLog(player.name + '이(가) 자동으로 드로우했습니다.');
       state.pendingBot = false;
+      state.botTimeoutId = null;
       advanceTurn();
     }, 600);
   }
 
   function newGame(seatCount) {
+    clearBotTimer();
     var count = clampSeatCount(seatCount);
     state.seatCount = count;
     state.currentTurn = 0;


### PR DESCRIPTION
## Summary
- track the scheduled bot autoplay timeout so it can be cancelled
- clear pending bot timers when the turn switches back to a human or a new game begins

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68df8d55b0b0832ea6c40d7180f244f6