### PR TITLE
Configure Render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ pnpm dev     # http://localhost:5173 에서 실행
 - `pnpm test:ui`: 간단한 비주얼 회귀 스냅샷 테스트(Table3D 모바일/데스크탑)
 
 테스트는 Vitest + Testing Library + jsdom 환경에서 실행되며, CSS를 로드해 레이아웃 클래스를 확인합니다.
+
+## Render 호스팅
+
+`render.yaml`이 포함되어 있어 Render에 Web Service로 배포할 수 있습니다.
+
+1. Render 대시보드에서 새 Web Service를 생성하고 이 저장소를 연결합니다.
+2. 빌드 커맨드: `npm install && npm run build`
+3. 시작 커맨드: `npm run start -- --host 0.0.0.0 --port $PORT`
+
+`vite.config.ts`에서 프리뷰 서버가 Render가 제공하는 포트를 자동으로 사용하도록 설정되어 있습니다.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "start": "vite preview",
     "test": "vitest",
     "test:ui": "vitest run src/ui/__tests__/visual.test.tsx"
   },

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: hoola-ui
+    env: node
+    buildCommand: npm install && npm run build
+    startCommand: npm run start -- --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: NODE_VERSION
+        value: 18

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
   server: {
     host: '0.0.0.0'
   },
+  preview: {
+    host: '0.0.0.0',
+    port: Number(process.env.PORT ?? '4173')
+  },
   build: {
     target: 'es2019'
   }


### PR DESCRIPTION
## Summary
- add Render deployment template and documentation for hosting the app as a web service
- expose a start script for `vite preview` so Render can launch the built app
- ensure the Vite preview server binds to Render's provided host and port

## Testing
- npm run dev *(fails: vite not found in environment due to unavailable dependencies)*
- npm test *(fails: vitest not found in environment due to unavailable dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa10abd64832ea505ce712cf06b86